### PR TITLE
Fix Inspector of import VDB is broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,6 @@ osx: &osx
    language: generic
 matrix:
    include:
-
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc5 CONAN_BUILD_TYPES=Release
-
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=lasote/conangcc6 CONAN_BUILD_TYPES=Release
-
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=lasote/conangcc7 CONAN_BUILD_TYPES=Release
-
       - <<: *osx
         osx_image: xcode9
         env: CONAN_APPLE_CLANG_VERSIONS=9.0

--- a/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/OpenVDBImporter.cs
+++ b/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/OpenVDBImporter.cs
@@ -1,15 +1,18 @@
 #if UNITY_2017_1_OR_NEWER
 
+using System;
 using UnityEngine;
 using System.IO;
 using UnityEditor.Experimental.AssetImporters;
 using System.Text.RegularExpressions;
 using Extensions;
+using Object = UnityEngine.Object;
 
 namespace OpenVDB
 {
+    [Serializable]
     [ScriptedImporter(1, "vdb")]
-    public class OpenVDBAssetImporter : ScriptedImporter
+    public class OpenVDBImporter : ScriptedImporter
     {
         [SerializeField] public OpenVDBStreamSettings streamSettings = new OpenVDBStreamSettings();
 

--- a/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/OpenVDBImporterEditor.cs
+++ b/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/OpenVDBImporterEditor.cs
@@ -7,7 +7,7 @@ using UnityEditor.Experimental.AssetImporters;
 
 namespace OpenVDB
 {
-    [CustomEditor(typeof(OpenVDBAssetImporter)), CanEditMultipleObjects]
+    [CustomEditor(typeof(OpenVDBImporter)), CanEditMultipleObjects]
     public class OpenVDBImporterEditor : ScriptedImporterEditor
     {
         public override void OnInspectorGUI()

--- a/OpenVDBForUnity/ProjectSettings/ProjectVersion.txt
+++ b/OpenVDBForUnity/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.2.1f1
+m_EditorVersion: 2018.2.0f2

--- a/OpenVDBForUnity/ProjectSettings/ProjectVersion.txt
+++ b/OpenVDBForUnity/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.2.0f2
+m_EditorVersion: 2018.2.1f1


### PR DESCRIPTION
This PR to fix this issue. https://github.com/karasusan/OpenVDBForUnity/issues/2

I cannot understand the behaviours of scripted importer but maybe fix it.
<img width="384" alt="screen_shot_2018-09-14_at_3_29_59_pm" src="https://user-images.githubusercontent.com/1132081/45533893-31e98d80-b834-11e8-980e-6db7bc8d6d21.png">

Sometimes, fix the inspector to push `Reset` button. 
<img width="415" alt="screen shot 2018-09-14 at 3 45 09 pm" src="https://user-images.githubusercontent.com/1132081/45534157-31052b80-b835-11e8-8006-154cf96a0d9f.png">
