### PR TITLE
Update the inspector layout to extract the material/texture

### DIFF
--- a/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/Extractor.cs
+++ b/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/Extractor.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+using UnityEditor;
+
+namespace OpenVDB
+{
+    public static class Extractor
+    {
+        public static IEnumerable<Object> FindSubassetsFromPath(string path)
+        {
+            return string.IsNullOrEmpty(path) ? null : AssetDatabase.LoadAllAssetsAtPath(path).Where(AssetDatabase.IsSubAsset);
+        }
+
+        public static T[] ExtractSubassetsFromPath<T>(string path, string destinationPath, string extension) where T : Object
+        {
+            var enumerable = FindSubassetsFromPath(path).Select(subasset => subasset as T).Where(obj => obj != null);
+            return enumerable.Select(subasset => ExtractFromAsset(subasset, Path.ChangeExtension(Path.Combine(destinationPath, subasset.name), extension))).ToArray();
+        }
+        
+        public static T ExtractFromAsset<T>(T subAsset, string destinationPath) where T : Object
+        {
+            var clone = Object.Instantiate(subAsset);
+            AssetDatabase.CreateAsset(clone, destinationPath);
+            return AssetDatabase.LoadAssetAtPath<T>(destinationPath);
+        }
+    }    
+}

--- a/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/Extractor.cs.meta
+++ b/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/Extractor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01bc90610b1ee44db86348bb57f679c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/OpenVDBImporterEditor.cs
+++ b/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/OpenVDBImporterEditor.cs
@@ -1,6 +1,7 @@
 #if UNITY_2017_1_OR_NEWER
 
 using System;
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 using UnityEditor.Experimental.AssetImporters;
@@ -10,20 +11,162 @@ namespace OpenVDB
     [CustomEditor(typeof(OpenVDBImporter)), CanEditMultipleObjects]
     public class OpenVDBImporterEditor : ScriptedImporterEditor
     {
+        private int _toolbar = 0;
+
+        private static void ShowSerializedPropertyArrayElement<T>(SerializedProperty property, int index) where T : UnityEngine.Object
+        {
+            var obj = property.GetArrayElementAtIndex(index).objectReferenceValue as T;
+
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.PrefixLabel(obj.name);
+            var newObj = EditorGUILayout.ObjectField(obj, typeof(T), false);
+            if (newObj.GetHashCode() != obj.GetHashCode())
+            {
+                property.GetArrayElementAtIndex(index).objectReferenceValue = newObj;
+            }
+            EditorGUILayout.EndHorizontal();
+        }
+
+        private static void SerializedPropertyUpdateArray<T>(SerializedProperty property, T[] objects) where T : UnityEngine.Object
+        {
+            property.ClearArray();
+            foreach (var obj in objects)
+            {
+                var index = property.arraySize;
+                property.InsertArrayElementAtIndex(index);
+                property.GetArrayElementAtIndex(index).objectReferenceValue = obj;
+            }
+        }
+
+
+        private static string GetRelativePathInProjectFolder(string path)
+        {
+            var projectPath = Path.GetDirectoryName(Application.dataPath) + Path.DirectorySeparatorChar;
+
+            if(!path.StartsWith(projectPath))
+                throw new InvalidOperationException($"Invalid path:{path}");
+            return path.Substring(projectPath.Length);
+        }
+
         public override void OnInspectorGUI()
         {
-            var pathSettings = "streamSettings.";
+            const string pathSettings = "streamSettings.";
+            var importer = serializedObject.targetObject as OpenVDBImporter;
+            if(importer == null)
+                throw new InvalidOperationException();
 
-            EditorGUILayout.LabelField("Scene", EditorStyles.boldLabel);
+            _toolbar = GUILayout.Toolbar( _toolbar,new []{ "Model", "Material" } );
+
+            switch (_toolbar)
             {
-                EditorGUI.indentLevel++;
-                var property = serializedObject.FindProperty(pathSettings + "scaleFactor");
-                if(property != null)
+                case 0:
                 {
-                    EditorGUILayout.PropertyField(property,
-                        new GUIContent("Scale Factor", "How much to scale the models compared to what is in the source file."));
+                    EditorGUILayout.LabelField("Meshes", EditorStyles.boldLabel);
+                    var property = serializedObject.FindProperty(pathSettings + "scaleFactor");
+                    if (property != null)
+                    {
+                        EditorGUILayout.PropertyField(property,
+                            new GUIContent("Scale Factor",
+                                "How much to scale the models compared to what is in the source file."));
+                    }
+                    break;
                 }
+                case 1:
+                {
+                    // Import Materials
+                    {
+                        var property = serializedObject.FindProperty(pathSettings + "importMaterials");
+                        if (property != null)
+                        {
+                            EditorGUILayout.PropertyField(property,
+                                new GUIContent("Import Materials",
+                                    "How much to scale the models compared to what is in the source file."));
+                        }
+                    }
+
+                    // Extract Textures
+                    {
+                        var property = serializedObject.FindProperty(pathSettings + "extractTextures");
+                        var disabled = property.boolValue;
+                        EditorGUI.BeginDisabledGroup(disabled);
+                        EditorGUILayout.BeginHorizontal();
+                        EditorGUILayout.PrefixLabel("Textures");
+                        if (GUILayout.Button("Extract Textures"))
+                        {
+                            var folder = EditorUtility.OpenFolderPanel("Select Textures Folder", Path.GetDirectoryName(importer.assetPath), "");
+                            if (!string.IsNullOrEmpty(folder))
+                            {
+                                folder = GetRelativePathInProjectFolder(folder);
+                                var externalTextures = Extractor.ExtractSubassetsFromPath<Texture>(importer.assetPath, folder, "asset");
+                                var texturesProperty = serializedObject.FindProperty(pathSettings + "textures");
+                                SerializedPropertyUpdateArray(texturesProperty, externalTextures);
+                                property.boolValue = true;
+                                ApplyAndImport();
+                            }
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUI.EndDisabledGroup();
+                    }
+
+                    // Extract Materials
+                    {
+                        var property = serializedObject.FindProperty(pathSettings + "extractMaterials");
+                        var disabled = property.boolValue;
+                        EditorGUI.BeginDisabledGroup(disabled);
+                        EditorGUILayout.BeginHorizontal();
+                        EditorGUILayout.PrefixLabel("Materials");
+                        if (GUILayout.Button("Extract Materials"))
+                        {
+                            var folder = EditorUtility.OpenFolderPanel("Select Materials Folder", Path.GetDirectoryName(importer.assetPath), "");
+                            if (!string.IsNullOrEmpty(folder))
+                            {
+                                folder = GetRelativePathInProjectFolder(folder);
+                                var externalMaterials = Extractor.ExtractSubassetsFromPath<Material>(importer.assetPath, folder, "mat");
+                                var materialsProperty = serializedObject.FindProperty(pathSettings + "materials");
+                                SerializedPropertyUpdateArray(materialsProperty, externalMaterials);
+                                property.boolValue = true;
+                                ApplyAndImport();
+                            }
+                        }
+                        EditorGUILayout.EndHorizontal();
+                        EditorGUI.EndDisabledGroup();
+                    }
+
+                    // Remapped Textures
+                    {
+                        var property = serializedObject.FindProperty(pathSettings + "textures");
+                        if (property.arraySize > 0)
+                        {
+                            EditorGUILayout.HelpBox("Textures assignments can be remapped below.", MessageType.Info);
+                            EditorGUILayout.LabelField("Remapped Textures", EditorStyles.boldLabel);
+
+                            for (var index = 0; index < property.arraySize; index++)
+                            {
+                                ShowSerializedPropertyArrayElement<Texture>(property, index);
+                            }
+                        }
+                    }
+
+                    // Remapped Materials
+                    {
+                        var property = serializedObject.FindProperty(pathSettings + "materials");
+                        if (property.arraySize > 0)
+                        {
+                            EditorGUILayout.HelpBox("Material assignments can be remapped below.", MessageType.Info);
+                            EditorGUILayout.LabelField("Remapped Materials", EditorStyles.boldLabel);
+
+                            for (var index = 0; index < property.arraySize; index++)
+                            {
+                                ShowSerializedPropertyArrayElement<Material>(property, index);
+                            }
+                        }
+                    }
+                    break;
+                }
+                default:
+                    throw new NotImplementedException();
             }
+
             EditorGUILayout.Separator();
 
             ApplyRevertGUI();

--- a/OpenVDBForUnity/Assets/OpenVDB/Scripts/Importer/OpenVDBStream.cs
+++ b/OpenVDBForUnity/Assets/OpenVDB/Scripts/Importer/OpenVDBStream.cs
@@ -13,24 +13,24 @@ namespace OpenVDB
         static List<OpenVDBStream> s_streams = new List<OpenVDBStream>();
         static bool s_initialized;
 
-        OpenVDBStreamDescriptor m_streamDesc;
-        GameObject m_go;
-        OpenVDBVolume m_volume;
+        private GameObject m_go;
+        private OpenVDBVolume m_volume;
+        private OpenVDBStreamDescriptor m_streamDescriptor { get; }
+        
 
-        public OpenVDBStreamDescriptor streamDescriptor { get { return m_streamDesc; } }
-        public GameObject gameObject { get { return m_go; } }
-        public Texture3D texture3D { get { return m_volume.texture3D; } }
-        public Mesh mesh { get { return m_volume.mesh; }}
+        public GameObject gameObject => m_go;
+        public Texture3D texture3D => m_volume.texture3D;
+        public Mesh mesh => m_volume.mesh;
 
-        public OpenVDBStream(GameObject go, OpenVDBStreamDescriptor streamDesc)
+        public OpenVDBStream(GameObject go, OpenVDBStreamDescriptor mStreamDesc)
         {
             m_go = go;
-            m_streamDesc = streamDesc;
+            m_streamDescriptor = mStreamDesc;
         }
 
         public void Dispose()
         {
-            OpenVDBStream.s_streams.Remove(this);
+            s_streams.Remove(this);
         }
 
         public bool Load()
@@ -41,19 +41,19 @@ namespace OpenVDB
                 s_initialized = true;
             }
             var context = oiContext.Create(m_go.GetInstanceID());
-            var settings = m_streamDesc.settings;
+            var settings = m_streamDescriptor.settings;
 
-            oiConfig config = new oiConfig();
+            var config = new oiConfig();
             config.SetDefaults();
             config.scaleFactor = settings.scaleFactor;
 
             context.SetConfig(ref config);
-            var path = Path.Combine(Application.streamingAssetsPath, m_streamDesc.pathToVDB);
+            var path = Path.Combine(Application.streamingAssetsPath, m_streamDescriptor.pathToVDB);
             var loaded = context.Load(path);
             if(loaded)
             {
                 UpdateVDB(context);
-                OpenVDBStream.s_streams.Add(this);
+                s_streams.Add(this);
             }
             else
             {
@@ -66,11 +66,9 @@ namespace OpenVDB
         void UpdateVDB(oiContext context)
         {
             m_volume = new OpenVDBVolume(context.volume);
-            if(m_volume != null)
-            {
-                m_volume.SyncDataBegin();
-                //m_volume.SyncDataEnd();
-            }
+            m_volume?.SyncDataBegin();
+            m_volume.texture3D.name = m_go.name;
+            //m_volume.SyncDataEnd();
             // Apply volume scale
             m_go.transform.localScale = m_volume.scale;
         }

--- a/OpenVDBForUnity/Assets/OpenVDB/Scripts/Importer/OpenVDBStreamSettings.cs
+++ b/OpenVDBForUnity/Assets/OpenVDB/Scripts/Importer/OpenVDBStreamSettings.cs
@@ -5,6 +5,18 @@ namespace OpenVDB
     [System.Serializable]
     public class OpenVDBStreamSettings
     {
+        // Meshes
         [SerializeField] public float scaleFactor = 0.01f;
+        
+        // Material
+        [SerializeField] public bool importMaterials = true;
+        
+        [SerializeField] public bool extractTextures = false;
+        
+        [SerializeField] public bool extractMaterials = false;
+        
+        [SerializeField] public Texture[] textures = new Texture[0];
+        
+        [SerializeField] public Material[] materials = new Material[0];
     }
 }


### PR DESCRIPTION
I add the feature to solve the issue https://github.com/karasusan/OpenVDBForUnity/issues/1.
I add two buttons to extract the texture/material.

![screen_shot_2018-09-17_at_9_03_59_pm](https://user-images.githubusercontent.com/1132081/45622206-26a99280-babe-11e8-95dc-49c9f26c5b97.png)

![screen_shot_2018-09-17_at_9_26_19_pm](https://user-images.githubusercontent.com/1132081/45622898-8f920a00-bac0-11e8-806e-541af3785d77.png)

You can replace the extracted texture/material.

![screen_shot_2018-09-17_at_9_29_03_pm](https://user-images.githubusercontent.com/1132081/45623019-e26bc180-bac0-11e8-9dbf-a141f1cbfb56.png)
