### PR TITLE
Change scriptingRuntimeVersion to ".NET 3.5"

### DIFF
--- a/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/OpenVDBImporterEditor.cs
+++ b/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/OpenVDBImporterEditor.cs
@@ -44,7 +44,7 @@ namespace OpenVDB
             var projectPath = Path.GetDirectoryName(Application.dataPath) + Path.DirectorySeparatorChar;
 
             if(!path.StartsWith(projectPath))
-                throw new InvalidOperationException($"Invalid path:{path}");
+                throw new InvalidOperationException(string.Format("Invalid path:{0}", path));
             return path.Substring(projectPath.Length);
         }
 

--- a/OpenVDBForUnity/Assets/OpenVDB/Scripts/Importer/OpenVDBStream.cs
+++ b/OpenVDBForUnity/Assets/OpenVDB/Scripts/Importer/OpenVDBStream.cs
@@ -17,10 +17,11 @@ namespace OpenVDB
         private OpenVDBVolume m_volume;
         private OpenVDBStreamDescriptor m_streamDescriptor { get; }
         
+        public GameObject gameObject { get { return m_go; } }
 
-        public GameObject gameObject => m_go;
-        public Texture3D texture3D => m_volume.texture3D;
-        public Mesh mesh => m_volume.mesh;
+        public Texture3D texture3D { get { return m_volume.texture3D; } }
+
+        public Mesh mesh { get { return m_volume.mesh; } } 
 
         public OpenVDBStream(GameObject go, OpenVDBStreamDescriptor mStreamDesc)
         {
@@ -66,9 +67,9 @@ namespace OpenVDB
         void UpdateVDB(oiContext context)
         {
             m_volume = new OpenVDBVolume(context.volume);
-            m_volume?.SyncDataBegin();
+            m_volume.SyncDataBegin();
             m_volume.texture3D.name = m_go.name;
-            //m_volume.SyncDataEnd();
+            
             // Apply volume scale
             m_go.transform.localScale = m_volume.scale;
         }

--- a/OpenVDBForUnity/ProjectSettings/ProjectSettings.asset
+++ b/OpenVDBForUnity/ProjectSettings/ProjectSettings.asset
@@ -560,7 +560,7 @@ PlayerSettings:
   incrementalIl2cppBuild: {}
   allowUnsafeCode: 0
   additionalIl2CppArgs: 
-  scriptingRuntimeVersion: 1
+  scriptingRuntimeVersion: 0
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
   m_MobileRenderingPath: 1


### PR DESCRIPTION
Fix this issue for compatibility.
https://github.com/karasusan/OpenVDBForUnity/issues/1#issuecomment-422418001

You can use both versions `.NET 3.5` and `.NET 4.5`
![screen_shot_2018-09-19_at_9_55_26_am](https://user-images.githubusercontent.com/1132081/45724677-4346e700-bbf2-11e8-8fa9-9ce62a06f050.png)
