### PR TITLE
Path.DirectorySeparatorChar returns incorrect character on Windows

### DIFF
--- a/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/OpenVDBImporterEditor.cs
+++ b/OpenVDBForUnity/Assets/OpenVDB/Editor/Importer/OpenVDBImporterEditor.cs
@@ -41,7 +41,7 @@ namespace OpenVDB
 
         private static string GetRelativePathInProjectFolder(string path)
         {
-            var projectPath = Path.GetDirectoryName(Application.dataPath) + Path.DirectorySeparatorChar;
+            var projectPath = Path.GetDirectoryName(Application.dataPath) + "/";
 
             if(!path.StartsWith(projectPath))
                 throw new InvalidOperationException($"Invalid path:{path}");


### PR DESCRIPTION
Check this.
https://github.com/karasusan/OpenVDBForUnity/issues/1#issuecomment-422611070

`Path.DirectorySeparatorChar` returns `\` on Windows.
But `Application.dataPath` returns the project path with separators is `/`.

I plan to add UnitTests to avoid these OS-dependent bugs.